### PR TITLE
Boolean fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Minimal implementation of [json-schema](https://json-schema.org/specification.ht
 * [ ] References
 * [ ] Test Serialization
 * [ ] Complete Feature List
+* [ ] Detect enum
+* [ ] Detect const
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,10 @@ impl Schema {
                     Some(Property::Value(specification @ PropertyInstance::Object { .. })),
                 ..
             }) => Some(&specification),
+            SchemaInner::Schema(SchemaDefinition {
+                specification: Some(Property::Value(specification @ PropertyInstance::Array { .. })),
+                ..
+            }) => Some(&specification),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ impl Schema {
 
     pub fn as_boolean(&self) -> Option<&PropertyInstance> {
         match self.specification() {
-            Some(boolean @ PropertyInstance::Boolean(_)) => Some(boolean),
+            Some(boolean @ PropertyInstance::Boolean) => Some(boolean),
             _ => None,
         }
     }

--- a/src/property.rs
+++ b/src/property.rs
@@ -26,7 +26,7 @@ pub struct RefProperty {
 pub enum PropertyInstance {
     Null,
 
-    Boolean(bool),
+    Boolean,
 
     Integer {
         #[serde(flatten)]
@@ -61,8 +61,8 @@ impl PropertyInstance {
                 Err(vec![format!("expected null found {:?}", unexpected_value)])
             }
 
-            (Boolean(_), Value::Bool(_)) => Ok(()),
-            (Boolean(_), unexpected_value) => Err(vec![format!(
+            (Boolean, Value::Bool(_)) => Ok(()),
+            (Boolean, unexpected_value) => Err(vec![format!(
                 "expected boolean found {:?}",
                 unexpected_value
             )]),


### PR DESCRIPTION
# The issue
I was using for CodeGen, and I found a very extrange bug, after a bit of digging I found out that every time I used a `type: boolean` the result out of `serde::try_from` just included the `URL`. 

# My fix
Even though I am new to Rust after fumbling around a bit I found the `PropertyInstance` and I was like, if `String` doesn't "depend" on another type why should `Boolean`.
I changed `Boolean(bool)` into `Boolean` and fixed all the `Boolean(_)` mentions on the code and it finally worked.

# Extra
Also I added missing features to the README. And added the ability to use specification when the json schema is an array type.