### PR TITLE
[DO NOT MERGE] Prototype support for JSON Schema version 2020-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # serde-json-schema
 
-Minimal implementation of [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html) using [serde-json](https://github.com/serde-rs/json). Also maintains backward compatibility with draft-07 schemas.
+Minimal implementation of [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html) using [serde-json](https://github.com/serde-rs/json).
 
 ## Example
 
@@ -37,24 +37,17 @@ This crate supports the following JSON Schema 2020-12 features:
 * `$dynamicAnchor` / `$dynamicRef` - Dynamic referencing
 * `$vocabulary` - Meta-schema vocabulary declarations
 * `$comment` - Schema comments
-* `$defs` - Schema definitions (replaces `definitions`)
-* `prefixItems` - Tuple validation (replaces `items` as array)
+* `$defs` - Schema definitions
+* `prefixItems` - Tuple validation
 * `items` - Additional items schema
-* `dependentRequired` / `dependentSchemas` - Property dependencies (replaces `dependencies`)
+* `dependentRequired` / `dependentSchemas` - Property dependencies
 * `unevaluatedProperties` / `unevaluatedItems` - Unevaluated applicators
 * `contains` with `minContains` / `maxContains` - Array containment validation
-
-### Backward Compatibility
-
-The crate also supports draft-07 keywords for backward compatibility:
-* `definitions` (use `$defs` in new schemas)
-* `dependencies` (use `dependentRequired` / `dependentSchemas` in new schemas)
 
 ## Features/TODO
 
 * [x] JSON Schema Core Type
 * [x] JSON Schema 2020-12 support
-* [x] Backward compatibility with draft-07
 * [ ] JSON Schema Validation (partial, possibly different crate or optional feature)
 * [ ] Codegen (definitely different crate)
 * [ ] RootSchema vs SubSchema handling (is that used often?)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,60 @@
 # serde-json-schema
 
-Minimal implementation of [json-schema](https://json-schema.org/specification.html) using [serde-json](https://github.com/serde-rs/json).
+Minimal implementation of [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html) using [serde-json](https://github.com/serde-rs/json). Also maintains backward compatibility with draft-07 schemas.
 
 ## Example
 
 ```rust
-// hang in there
+use serde_json_schema::Schema;
+use std::convert::TryFrom;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let schema_json = r#"{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.com/product.schema.json",
+        "title": "Product",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "price": { "type": "number", "exclusiveMinimum": 0 }
+        },
+        "required": ["name", "price"]
+    }"#;
+
+    let schema = Schema::try_from(schema_json)?;
+    println!("{:#?}", schema);
+    Ok(())
+}
 ```
+
+## JSON Schema 2020-12 Features
+
+This crate supports the following JSON Schema 2020-12 features:
+
+* `$schema` - Schema dialect identifier
+* `$id` - Schema identifier
+* `$anchor` - Plain-name fragment identifiers
+* `$dynamicAnchor` / `$dynamicRef` - Dynamic referencing
+* `$vocabulary` - Meta-schema vocabulary declarations
+* `$comment` - Schema comments
+* `$defs` - Schema definitions (replaces `definitions`)
+* `prefixItems` - Tuple validation (replaces `items` as array)
+* `items` - Additional items schema
+* `dependentRequired` / `dependentSchemas` - Property dependencies (replaces `dependencies`)
+* `unevaluatedProperties` / `unevaluatedItems` - Unevaluated applicators
+* `contains` with `minContains` / `maxContains` - Array containment validation
+
+### Backward Compatibility
+
+The crate also supports draft-07 keywords for backward compatibility:
+* `definitions` (use `$defs` in new schemas)
+* `dependencies` (use `dependentRequired` / `dependentSchemas` in new schemas)
 
 ## Features/TODO
 
 * [x] JSON Schema Core Type
+* [x] JSON Schema 2020-12 support
+* [x] Backward compatibility with draft-07
 * [ ] JSON Schema Validation (partial, possibly different crate or optional feature)
 * [ ] Codegen (definitely different crate)
 * [ ] RootSchema vs SubSchema handling (is that used often?)

--- a/examples/address.schema.json
+++ b/examples/address.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "An address similar to http://microformats.org/wiki/h-card",
   "type": "object",
   "properties": {
@@ -26,8 +26,12 @@
       "type": "string"
     }
   },
-  "dependencies": {
-    "post-office-box": [ "street-address" ],
-    "extended-address": [ "street-address" ]
+  "dependentRequired": {
+    "post-office-box": [
+      "street-address"
+    ],
+    "extended-address": [
+      "street-address"
+    ]
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! This crates provides simply the `Schema` struct. It resembles the latest (draft-07) [json-schema core spec](https://json-schema.org/latest/json-schema-core.html).
+//! This crates provides simply the `Schema` struct. It resembles the [JSON Schema 2020-12 spec](https://json-schema.org/draft/2020-12/json-schema-core.html).
+//! It also maintains backward compatibility with draft-07 schemas.
 //! If this spec is no longer up-to-date by the time you read this, please open a [new issue](https://github.com/hoodie/serde-json-schema/issues/new).
 //!
 //! If this type seems a bit confusing, then it's because json-schema is a bit too flexible.
@@ -183,35 +184,35 @@ impl Schema {
 }
 
 impl TryFrom<serde_json::Value> for Schema {
-    type Error = crate::error::Error;
+    type Error = error::Error;
     fn try_from(v: serde_json::Value) -> Result<Schema> {
         Ok(serde_json::from_value(v)?)
     }
 }
 
 impl TryFrom<&str> for Schema {
-    type Error = crate::error::Error;
+    type Error = error::Error;
     fn try_from(s: &str) -> Result<Schema> {
         Ok(serde_json::from_str(s)?)
     }
 }
 
 impl TryFrom<String> for Schema {
-    type Error = crate::error::Error;
+    type Error = error::Error;
     fn try_from(s: String) -> Result<Schema> {
         Ok(serde_json::from_str(&s)?)
     }
 }
 
 impl TryFrom<&str> for SchemaDefinition {
-    type Error = crate::error::Error;
+    type Error = error::Error;
     fn try_from(s: &str) -> Result<SchemaDefinition> {
         Ok(serde_json::from_str(s)?)
     }
 }
 
 impl TryFrom<String> for SchemaDefinition {
-    type Error = crate::error::Error;
+    type Error = error::Error;
     fn try_from(s: String) -> Result<SchemaDefinition> {
         Ok(serde_json::from_str(&s)?)
     }
@@ -225,13 +226,46 @@ pub(crate) struct SchemaDefinition {
 
     #[serde(rename = "$schema")]
     pub schema: Option<Url>,
+
+    /// JSON Schema 2020-12: $anchor keyword for plain-name fragment identifiers
+    #[serde(rename = "$anchor", skip_serializing_if = "Option::is_none")]
+    pub anchor: Option<String>,
+
+    /// JSON Schema 2020-12: $dynamicAnchor for dynamic referencing
+    #[serde(rename = "$dynamicAnchor", skip_serializing_if = "Option::is_none")]
+    pub dynamic_anchor: Option<String>,
+
+    /// JSON Schema 2020-12: $vocabulary for meta-schema vocabulary declarations
+    #[serde(rename = "$vocabulary", skip_serializing_if = "Option::is_none")]
+    pub vocabulary: Option<HashMap<String, bool>>,
+
+    /// JSON Schema 2020-12: $comment for schema comments
+    #[serde(rename = "$comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    pub title: Option<String>,
     pub description: Option<String>,
-    // pub properties: HashMap<String, Property>,
+
+    /// draft-07: dependencies (deprecated in 2020-12, use dependentSchemas/dependentRequired)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<HashMap<String, Vec<String>>>,
+
+    /// JSON Schema 2020-12: dependentRequired replaces dependencies for required properties
+    #[serde(rename = "dependentRequired", skip_serializing_if = "Option::is_none")]
+    pub dependent_required: Option<HashMap<String, Vec<String>>>,
+
+    /// JSON Schema 2020-12: dependentSchemas replaces dependencies for schema dependencies
+    #[serde(rename = "dependentSchemas", skip_serializing_if = "Option::is_none")]
+    pub dependent_schemas: Option<HashMap<String, SchemaDefinition>>,
 
     #[serde(flatten)]
     pub specification: Option<Property>,
 
+    /// draft-07: definitions (deprecated in 2020-12, use $defs)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub definitions: Option<HashMap<String, SchemaDefinition>>,
+
+    /// JSON Schema 2020-12: $defs replaces definitions
+    #[serde(rename = "$defs", skip_serializing_if = "Option::is_none")]
+    pub defs: Option<HashMap<String, SchemaDefinition>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 //! This crates provides simply the `Schema` struct. It resembles the [JSON Schema 2020-12 spec](https://json-schema.org/draft/2020-12/json-schema-core.html).
-//! It also maintains backward compatibility with draft-07 schemas.
 //! If this spec is no longer up-to-date by the time you read this, please open a [new issue](https://github.com/hoodie/serde-json-schema/issues/new).
 //!
 //! If this type seems a bit confusing, then it's because json-schema is a bit too flexible.
@@ -246,26 +245,18 @@ pub(crate) struct SchemaDefinition {
     pub title: Option<String>,
     pub description: Option<String>,
 
-    /// draft-07: dependencies (deprecated in 2020-12, use dependentSchemas/dependentRequired)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dependencies: Option<HashMap<String, Vec<String>>>,
-
-    /// JSON Schema 2020-12: dependentRequired replaces dependencies for required properties
+    /// JSON Schema 2020-12: dependentRequired for property dependencies
     #[serde(rename = "dependentRequired", skip_serializing_if = "Option::is_none")]
     pub dependent_required: Option<HashMap<String, Vec<String>>>,
 
-    /// JSON Schema 2020-12: dependentSchemas replaces dependencies for schema dependencies
+    /// JSON Schema 2020-12: dependentSchemas for schema dependencies
     #[serde(rename = "dependentSchemas", skip_serializing_if = "Option::is_none")]
     pub dependent_schemas: Option<HashMap<String, SchemaDefinition>>,
 
     #[serde(flatten)]
     pub specification: Option<Property>,
 
-    /// draft-07: definitions (deprecated in 2020-12, use $defs)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub definitions: Option<HashMap<String, SchemaDefinition>>,
-
-    /// JSON Schema 2020-12: $defs replaces definitions
+    /// JSON Schema 2020-12: $defs for schema definitions
     #[serde(rename = "$defs", skip_serializing_if = "Option::is_none")]
     pub defs: Option<HashMap<String, SchemaDefinition>>,
 }

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,10 +1,13 @@
-//! Represents the [Instance Data Model](https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1)
+//! Represents the [Instance Data Model](https://json-schema.org/draft/2020-12/json-schema-core.html#section-4.2.1)
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use std::{collections::HashMap, str::Split};
 
-use crate::{validation::NumberCriteria, Schema};
+use crate::{
+    validation::{NumberCriteria, StringCriteria},
+    Schema,
+};
 
 /// Either a `PropertyInstance` or a reference
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -14,10 +17,45 @@ pub enum Property {
     Ref(RefProperty),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// A reference to another schema using $ref or $dynamicRef
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct RefProperty {
-    #[serde(rename = "$ref")]
-    pub reference: String,
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+
+    /// JSON Schema 2020-12: $dynamicRef for dynamic referencing
+    #[serde(rename = "$dynamicRef", skip_serializing_if = "Option::is_none")]
+    pub dynamic_reference: Option<String>,
+}
+
+// Custom deserializer for RefProperty that only matches if at least one ref is present
+impl<'de> Deserialize<'de> for RefProperty {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RefPropertyHelper {
+            #[serde(rename = "$ref")]
+            reference: Option<String>,
+            #[serde(rename = "$dynamicRef")]
+            dynamic_reference: Option<String>,
+        }
+
+        let helper = RefPropertyHelper::deserialize(deserializer)?;
+
+        // Only succeed if at least one ref field is present
+        if helper.reference.is_none() && helper.dynamic_reference.is_none() {
+            return Err(serde::de::Error::custom(
+                "RefProperty requires at least $ref or $dynamicRef",
+            ));
+        }
+
+        Ok(RefProperty {
+            reference: helper.reference,
+            dynamic_reference: helper.dynamic_reference,
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -30,7 +68,14 @@ enum Data<'a> {
 
 fn get_items(p: &Property) -> Option<&PropertyInstance> {
     match p {
-        Property::Value(PropertyInstance::Array { items }) => Some(&**items),
+        Property::Value(PropertyInstance::Array {
+            items: Some(items), ..
+        }) => {
+            match items.as_ref() {
+                ArrayItems::Schema(schema) => Some(schema),
+                ArrayItems::Tuple(_) => None, // Tuple items don't have a single schema
+            }
+        }
         _ => None,
     }
 }
@@ -67,8 +112,13 @@ fn find_ref<'a>(mut path: Split<'a, char>, mut data: Data<'a>) -> Option<Data<'a
 }
 
 impl RefProperty {
-    pub fn deref<'a>(&'a self, schema: &'a Schema) -> Option<&PropertyInstance> {
-        let reference = self.reference.strip_prefix("#/")?;
+    pub fn deref<'a>(&'a self, schema: &'a Schema) -> Option<&'a PropertyInstance> {
+        // Try $ref first, then fall back to $dynamicRef
+        let ref_value = self
+            .reference
+            .as_ref()
+            .or(self.dynamic_reference.as_ref())?;
+        let reference = ref_value.strip_prefix("#/")?;
         let path = reference.split('/');
         match find_ref(path, Data::Schema(schema))? {
             Data::Prop(v) => match v {
@@ -81,7 +131,7 @@ impl RefProperty {
     }
 }
 
-/// Represents the [Instance Data Model](https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1)
+/// Represents the [Instance Data Model](https://json-schema.org/draft/2020-12/json-schema-core.html#section-4.2.1)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum PropertyInstance {
@@ -94,12 +144,64 @@ pub enum PropertyInstance {
         criteria: NumberCriteria,
     },
     Object {
+        #[serde(default)]
         properties: HashMap<String, Property>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         required: Option<Vec<String>>,
+        /// JSON Schema 2020-12: additionalProperties
+        #[serde(
+            rename = "additionalProperties",
+            skip_serializing_if = "Option::is_none"
+        )]
+        additional_properties: Option<Box<AdditionalProperties>>,
+        /// JSON Schema 2020-12: unevaluatedProperties
+        #[serde(
+            rename = "unevaluatedProperties",
+            skip_serializing_if = "Option::is_none"
+        )]
+        unevaluated_properties: Option<Box<AdditionalProperties>>,
+        /// JSON Schema 2020-12: patternProperties
+        #[serde(rename = "patternProperties", skip_serializing_if = "Option::is_none")]
+        pattern_properties: Option<HashMap<String, Property>>,
+        /// Minimum number of properties
+        #[serde(rename = "minProperties", skip_serializing_if = "Option::is_none")]
+        min_properties: Option<u64>,
+        /// Maximum number of properties
+        #[serde(rename = "maxProperties", skip_serializing_if = "Option::is_none")]
+        max_properties: Option<u64>,
+        /// Property names schema
+        #[serde(rename = "propertyNames", skip_serializing_if = "Option::is_none")]
+        property_names: Option<Box<PropertyInstance>>,
     },
 
     Array {
-        items: Box<PropertyInstance>,
+        /// JSON Schema 2020-12: items now only accepts a single schema (for items beyond prefixItems)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        items: Option<Box<ArrayItems>>,
+        /// JSON Schema 2020-12: prefixItems replaces tuple validation (items as array in draft-07)
+        #[serde(rename = "prefixItems", skip_serializing_if = "Option::is_none")]
+        prefix_items: Option<Vec<Property>>,
+        /// JSON Schema 2020-12: unevaluatedItems
+        #[serde(rename = "unevaluatedItems", skip_serializing_if = "Option::is_none")]
+        unevaluated_items: Option<Box<AdditionalProperties>>,
+        /// Contains validation
+        #[serde(skip_serializing_if = "Option::is_none")]
+        contains: Option<Box<Property>>,
+        /// Minimum number of contains
+        #[serde(rename = "minContains", skip_serializing_if = "Option::is_none")]
+        min_contains: Option<u64>,
+        /// Maximum number of contains
+        #[serde(rename = "maxContains", skip_serializing_if = "Option::is_none")]
+        max_contains: Option<u64>,
+        /// Minimum items
+        #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
+        min_items: Option<u64>,
+        /// Maximum items
+        #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
+        max_items: Option<u64>,
+        /// Unique items constraint
+        #[serde(rename = "uniqueItems", skip_serializing_if = "Option::is_none")]
+        unique_items: Option<bool>,
     },
 
     Number {
@@ -107,7 +209,28 @@ pub enum PropertyInstance {
         criteria: NumberCriteria,
     },
 
-    String,
+    String {
+        #[serde(flatten)]
+        criteria: StringCriteria,
+    },
+}
+
+/// Represents either a schema or a boolean for additionalProperties/unevaluatedProperties/unevaluatedItems
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum AdditionalProperties {
+    Boolean(bool),
+    Schema(Property),
+}
+
+/// Represents items in an array - can be a single schema or array of schemas (for draft-07 compatibility)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ArrayItems {
+    /// Single schema for all items (2020-12 style)
+    Schema(PropertyInstance),
+    /// Array of schemas for tuple validation (draft-07 style, deprecated in 2020-12)
+    Tuple(Vec<Property>),
 }
 
 impl PropertyInstance {
@@ -128,8 +251,8 @@ impl PropertyInstance {
                 unexpected_value
             )]),
 
-            (String, Value::String(_)) => Ok(()),
-            (String, unexpected_value) => Err(vec![format!(
+            (String { .. }, Value::String(_)) => Ok(()),
+            (String { .. }, unexpected_value) => Err(vec![format!(
                 "expected string found {:?}",
                 unexpected_value
             )]),
@@ -146,13 +269,60 @@ impl PropertyInstance {
                 unexpected_value
             )]),
 
-            (Array { items }, Value::Array(elems)) => {
-                let errors: Vec<std::string::String> = elems
-                    .iter()
-                    .map(|value| items.validate(value))
-                    .filter_map(Result::err)
-                    .flat_map(|errors| errors.into_iter())
-                    .collect();
+            (
+                Array {
+                    items,
+                    prefix_items,
+                    ..
+                },
+                Value::Array(elems),
+            ) => {
+                let mut errors = Vec::new();
+
+                // Validate prefix items if present (tuple validation)
+                if let Some(prefix) = prefix_items {
+                    for (i, (elem, schema)) in elems.iter().zip(prefix.iter()).enumerate() {
+                        match schema {
+                            Property::Value(schema) => {
+                                if let Err(e) = schema.validate(elem) {
+                                    errors.extend(e.into_iter().map(|e| format!("[{}]: {}", i, e)));
+                                }
+                            }
+                            Property::Ref(_) => unimplemented!("$ref in prefixItems"),
+                        }
+                    }
+                }
+
+                // Validate remaining items with items schema
+                let prefix_len = prefix_items.as_ref().map(|p| p.len()).unwrap_or(0);
+                if let Some(items_schema) = items {
+                    for (i, elem) in elems.iter().enumerate().skip(prefix_len) {
+                        match items_schema.as_ref() {
+                            ArrayItems::Schema(schema) => {
+                                if let Err(e) = schema.validate(elem) {
+                                    errors.extend(e.into_iter().map(|e| format!("[{}]: {}", i, e)));
+                                }
+                            }
+                            ArrayItems::Tuple(schemas) => {
+                                // draft-07 tuple validation fallback
+                                if let Some(schema) = schemas.get(i) {
+                                    match schema {
+                                        Property::Value(schema) => {
+                                            if let Err(e) = schema.validate(elem) {
+                                                errors.extend(
+                                                    e.into_iter()
+                                                        .map(|e| format!("[{}]: {}", i, e)),
+                                                );
+                                            }
+                                        }
+                                        Property::Ref(_) => unimplemented!("$ref in items tuple"),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 if errors.is_empty() {
                     Ok(())
                 } else {
@@ -167,6 +337,7 @@ impl PropertyInstance {
                 Object {
                     properties,
                     required,
+                    ..
                 },
                 Value::Object(object),
             ) => {

--- a/src/property.rs
+++ b/src/property.rs
@@ -70,12 +70,7 @@ fn get_items(p: &Property) -> Option<&PropertyInstance> {
     match p {
         Property::Value(PropertyInstance::Array {
             items: Some(items), ..
-        }) => {
-            match items.as_ref() {
-                ArrayItems::Schema(schema) => Some(schema),
-                ArrayItems::Tuple(_) => None, // Tuple items don't have a single schema
-            }
-        }
+        }) => Some(items.as_ref()),
         _ => None,
     }
 }
@@ -175,10 +170,10 @@ pub enum PropertyInstance {
     },
 
     Array {
-        /// JSON Schema 2020-12: items now only accepts a single schema (for items beyond prefixItems)
+        /// JSON Schema 2020-12: items accepts a single schema (for items beyond prefixItems)
         #[serde(skip_serializing_if = "Option::is_none")]
-        items: Option<Box<ArrayItems>>,
-        /// JSON Schema 2020-12: prefixItems replaces tuple validation (items as array in draft-07)
+        items: Option<Box<PropertyInstance>>,
+        /// JSON Schema 2020-12: prefixItems for tuple validation
         #[serde(rename = "prefixItems", skip_serializing_if = "Option::is_none")]
         prefix_items: Option<Vec<Property>>,
         /// JSON Schema 2020-12: unevaluatedItems
@@ -221,16 +216,6 @@ pub enum PropertyInstance {
 pub enum AdditionalProperties {
     Boolean(bool),
     Schema(Property),
-}
-
-/// Represents items in an array - can be a single schema or array of schemas (for draft-07 compatibility)
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum ArrayItems {
-    /// Single schema for all items (2020-12 style)
-    Schema(PropertyInstance),
-    /// Array of schemas for tuple validation (draft-07 style, deprecated in 2020-12)
-    Tuple(Vec<Property>),
 }
 
 impl PropertyInstance {
@@ -297,28 +282,8 @@ impl PropertyInstance {
                 let prefix_len = prefix_items.as_ref().map(|p| p.len()).unwrap_or(0);
                 if let Some(items_schema) = items {
                     for (i, elem) in elems.iter().enumerate().skip(prefix_len) {
-                        match items_schema.as_ref() {
-                            ArrayItems::Schema(schema) => {
-                                if let Err(e) = schema.validate(elem) {
-                                    errors.extend(e.into_iter().map(|e| format!("[{}]: {}", i, e)));
-                                }
-                            }
-                            ArrayItems::Tuple(schemas) => {
-                                // draft-07 tuple validation fallback
-                                if let Some(schema) = schemas.get(i) {
-                                    match schema {
-                                        Property::Value(schema) => {
-                                            if let Err(e) = schema.validate(elem) {
-                                                errors.extend(
-                                                    e.into_iter()
-                                                        .map(|e| format!("[{}]: {}", i, e)),
-                                                );
-                                            }
-                                        }
-                                        Property::Ref(_) => unimplemented!("$ref in items tuple"),
-                                    }
-                                }
-                            }
+                        if let Err(e) = items_schema.validate(elem) {
+                            errors.extend(e.into_iter().map(|e| format!("[{}]: {}", i, e)));
                         }
                     }
                 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,8 +1,60 @@
 use serde::{Deserialize, Serialize};
 
-/// Number validation Criteria (WIP)
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Number validation Criteria
+/// Supports both draft-07 and 2020-12 syntax
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct NumberCriteria {
-    exclusive_minimum: Option<serde_json::Value>,
+    /// Minimum value (inclusive)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<serde_json::Number>,
+
+    /// Maximum value (inclusive)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<serde_json::Number>,
+
+    /// Exclusive minimum value (2020-12 uses number, draft-07 used boolean)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_minimum: Option<serde_json::Value>,
+
+    /// Exclusive maximum value (2020-12 uses number, draft-07 used boolean)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_maximum: Option<serde_json::Value>,
+
+    /// Value must be a multiple of this number
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multiple_of: Option<serde_json::Number>,
+}
+
+/// String validation criteria
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StringCriteria {
+    /// Minimum string length
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<u64>,
+
+    /// Maximum string length
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<u64>,
+
+    /// Regular expression pattern the string must match
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+
+    /// Semantic format (e.g., "date-time", "email", "uri")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+
+    /// JSON Schema 2020-12: Content media type
+    #[serde(rename = "contentMediaType", skip_serializing_if = "Option::is_none")]
+    pub content_media_type: Option<String>,
+
+    /// JSON Schema 2020-12: Content encoding (e.g., "base64")
+    #[serde(rename = "contentEncoding", skip_serializing_if = "Option::is_none")]
+    pub content_encoding: Option<String>,
+
+    /// JSON Schema 2020-12: Content schema for encoded content
+    #[serde(rename = "contentSchema", skip_serializing_if = "Option::is_none")]
+    pub content_schema: Option<Box<serde_json::Value>>,
 }

--- a/tests/fixtures/address.schema.json
+++ b/tests/fixtures/address.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "An address similar to http://microformats.org/wiki/h-card",
   "type": "object",
   "properties": {
@@ -26,9 +26,17 @@
       "type": "string"
     }
   },
-  "required": [ "locality", "region", "country-name" ],
-  "dependencies": {
-    "post-office-box": [ "street-address" ],
-    "extended-address": [ "street-address" ]
+  "required": [
+    "locality",
+    "region",
+    "country-name"
+  ],
+  "dependentRequired": {
+    "post-office-box": [
+      "street-address"
+    ],
+    "extended-address": [
+      "street-address"
+    ]
   }
 }

--- a/tests/fixtures/calendar.schema.json
+++ b/tests/fixtures/calendar.schema.json
@@ -1,9 +1,12 @@
 {
-  "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/calendar.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A representation of an event",
   "type": "object",
-  "required": [ "dtstart", "summary" ],
+  "required": [
+    "dtstart",
+    "summary"
+  ],
   "properties": {
     "dtstart": {
       "type": "string",
@@ -41,7 +44,7 @@
       "type": "string"
     },
     "geo": {
-      "$ref": "http://example.com/geo.schema.json"
+      "$ref": "geographical-location.schema.json"
     }
   }
 }

--- a/tests/fixtures/card.schema.json
+++ b/tests/fixtures/card.schema.json
@@ -1,9 +1,12 @@
 {
-  "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/card.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A representation of a person, company, organization, or place",
   "type": "object",
-  "required": [ "familyName", "givenName" ],
+  "required": [
+    "familyName",
+    "givenName"
+  ],
   "properties": {
     "fn": {
       "description": "Formatted Name",
@@ -61,8 +64,12 @@
         }
       }
     },
-    "adr": { "$ref": "http://example.com/address.schema.json" },
-    "geo": { "$ref": "http://example.com/geographical-location.schema.json" },
+    "adr": {
+      "$ref": "address.schema.json"
+    },
+    "geo": {
+      "$ref": "geographical-location.schema.json"
+    },
     "tz": {
       "type": "string"
     },

--- a/tests/fixtures/geographical-location.schema.json
+++ b/tests/fixtures/geographical-location.schema.json
@@ -1,9 +1,12 @@
 {
   "$id": "https://example.com/geographical-location.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Longitude and Latitude Values",
   "description": "A geographical coordinate.",
-  "required": [ "latitude", "longitude" ],
+  "required": [
+    "latitude",
+    "longitude"
+  ],
   "type": "object",
   "properties": {
     "latitude": {

--- a/tests/fixtures/green_door.schema.json
+++ b/tests/fixtures/green_door.schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/product.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
   "title": "Product",
   "description": "A product from Acme's catalog",
   "type": "object",
@@ -19,5 +19,8 @@
       "exclusiveMinimum": 0
     }
   },
-  "required": [ "productId", "productName" ]
+  "required": [
+    "productId",
+    "productName"
+  ]
 }

--- a/tests/fixtures/product-2020-12.schema.json
+++ b/tests/fixtures/product-2020-12.schema.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/product.schema.json",
+    "$comment": "A product schema demonstrating JSON Schema 2020-12 features",
+    "title": "Product",
+    "description": "A product from Acme's catalog",
+    "type": "object",
+    "properties": {
+        "productId": {
+            "description": "The unique identifier for a product",
+            "type": "integer",
+            "exclusiveMinimum": 0
+        },
+        "productName": {
+            "description": "Name of the product",
+            "type": "string",
+            "minLength": 1
+        },
+        "price": {
+            "description": "The price of the product",
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "tags": {
+            "description": "Tags for the product",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "dimensions": {
+            "$ref": "#/$defs/dimensions"
+        }
+    },
+    "required": [
+        "productId",
+        "productName",
+        "price"
+    ],
+    "dependentRequired": {
+        "dimensions": [
+            "weight"
+        ]
+    },
+    "$defs": {
+        "dimensions": {
+            "type": "object",
+            "properties": {
+                "length": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "height": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "length",
+                "width",
+                "height"
+            ]
+        }
+    }
+}

--- a/tests/fixtures/root_array.schema.json
+++ b/tests/fixtures/root_array.schema.json
@@ -1,9 +1,9 @@
 {
-    "$id": "https://example.com/address.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "An array of strings, you know",
-    "type": "array",
-    "items": {
-      "type": "string"
-    }
+  "$id": "https://example.com/root-array.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An array of strings, you know",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,7 +33,7 @@ mod numbers {
     #[test]
     fn number_spec() {
         let raw_schema: &str = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Product",
     "description": "A product from Acme's catalog",
     "type": "number"
@@ -50,7 +50,7 @@ mod numbers {
     #[should_panic]
     fn number_spec_negative() {
         let raw_schema: &str = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Product",
     "description": "A product from Acme's catalog",
     "type": "number"
@@ -65,8 +65,8 @@ mod numbers {
     #[test]
     fn number_types() {
         let raw_schema: &str = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://example.com/product.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/product.schema.json",
     "title": "Product",
     "description": "A product from Acme's catalog",
     "type": "object",
@@ -133,7 +133,7 @@ mod examples {
         let schema: Schema =
             serde_json::from_str(include_str!("./fixtures/card.schema.json")).unwrap();
         println!("{:#?}", schema.draft_version());
-        assert_eq!(schema.draft_version(), Some("draft-07"))
+        assert_eq!(schema.draft_version(), Some("draft"))
     }
 
     #[test]
@@ -154,12 +154,12 @@ mod spec {
     fn required_not_required() {
         let raw_schema = r#"{
   "$id": "https://example.com/address.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "An address similar to http://microformats.org/wiki/h-card",
   "type": "object",
   "properties": {
   },
-  "dependencies": {
+  "dependentRequired": {
     "post-office-box": [ "street-address" ],
     "extended-address": [ "street-address" ]
   }
@@ -169,7 +169,7 @@ mod spec {
         assert!(schema.specification().is_some())
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.1
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.1
     #[test]
     #[should_panic]
     fn schema_must_be_a_url() {
@@ -188,12 +188,12 @@ mod spec {
         Schema::try_from(raw_schema).unwrap();
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2
     #[test]
     #[should_panic]
     fn id_must_not_contain_spaces() {
         let raw_schema = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "not a uri",
     "description": "A product from Acme's catalog",
     "type": "object",
@@ -209,44 +209,44 @@ mod spec {
         println!("{:#?}", schema);
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2
     #[test]
     fn id_may_be_a_uuid() {
         let raw_schema = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
     }"#;
         let schema = Schema::try_from(raw_schema).unwrap();
         println!("{:#?}", schema);
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2
     #[test]
     fn id_may_be_a_fragment() {
         let raw_schema = r##"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "#foo"
     }"##;
         let schema = Schema::try_from(raw_schema).unwrap();
         println!("{:#?}", schema);
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2
     #[test]
     fn id_may_be_a_path() {
         let raw_schema = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "t/inner.json"
     }"#;
         let schema = Schema::try_from(raw_schema).unwrap();
         println!("{:#?}", schema);
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2
     #[test]
     fn id_is_optional() {
         let raw_schema = r#"{
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A product from Acme's catalog",
     "type": "object",
     "properties": {
@@ -263,18 +263,19 @@ mod spec {
         assert!(schema.id().is_none());
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2.4
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4
     ///
-    /// TODO: definitions are not yet implemented
+    /// JSON Schema 2020-12 uses $defs instead of definitions
     #[test]
     fn subschema() {
         let raw_schema = r##"{
-        "$id": "http://example.com/root.json",
-        "definitions": {
+        "$id": "https://example.com/root.json",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
             "A": { "$id": "#foo" },
             "B": {
                 "$id": "other.json",
-                "definitions": {
+                "$defs": {
                     "X": { "$id": "#bar" },
                     "Y": { "$id": "t/inner.json" }
                 }
@@ -289,17 +290,17 @@ mod spec {
         println!("{:#?}", schema);
     }
 
-    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.8.2.4
+    /// https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4
     ///
-    /// TODO: definitions are not yet implemented
+    /// JSON Schema 2020-12 uses $defs instead of definitions
     #[test]
     #[ignore]
     fn subschema_no_ids() {
         let raw_schema = r#"{
-        "definitions": {
+        "$defs": {
             "A": {},
             "B": {
-                "definitions": {
+                "$defs": {
                 }
             },
             "C": {
@@ -382,5 +383,215 @@ mod validation {
                 .unwrap();
         // TODO: make more concrete error type
         schema.validate(&json_missing).unwrap();
+    }
+}
+
+/// Tests for JSON Schema 2020-12 specific features
+mod json_schema_2020_12 {
+    use serde_json::json;
+    use serde_json_schema::*;
+
+    /// Test prefixItems for tuple validation (2020-12 feature)
+    #[test]
+    fn prefix_items() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "prefixItems": [
+                { "type": "string" },
+                { "type": "integer" }
+            ],
+            "items": { "type": "boolean" }
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+
+        // Valid: matches prefixItems types
+        schema.validate(&json!(["hello", 42])).unwrap();
+        // Valid: extra items match items schema
+        schema.validate(&json!(["hello", 42, true, false])).unwrap();
+    }
+
+    /// Test $anchor keyword (2020-12 feature)
+    #[test]
+    fn anchor() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/schemas/address",
+            "$anchor": "address",
+            "type": "object",
+            "properties": {
+                "street": { "type": "string" }
+            }
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test $dynamicAnchor and $dynamicRef (2020-12 feature)
+    #[test]
+    fn dynamic_anchor() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/schemas/base",
+            "$dynamicAnchor": "node",
+            "type": "object"
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test $vocabulary (2020-12 meta-schema feature)
+    #[test]
+    fn vocabulary() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$vocabulary": {
+                "https://json-schema.org/draft/2020-12/vocab/core": true,
+                "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+                "https://json-schema.org/draft/2020-12/vocab/validation": true
+            }
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test $comment (included in 2020-12)
+    #[test]
+    fn comment() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$comment": "This is a comment explaining the schema",
+            "type": "string"
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test $defs (2020-12 replacement for definitions)
+    #[test]
+    fn defs() {
+        let raw_schema = r##"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "positiveInteger": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                }
+            },
+            "type": "object",
+            "properties": {
+                "count": { "$ref": "#/$defs/positiveInteger" }
+            }
+        }"##;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test dependentRequired (2020-12 replacement for dependencies)
+    #[test]
+    fn dependent_required() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "credit_card": { "type": "string" },
+                "billing_address": { "type": "string" }
+            },
+            "dependentRequired": {
+                "credit_card": ["billing_address"]
+            }
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test unevaluatedProperties (2020-12 feature)
+    #[test]
+    fn unevaluated_properties() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test unevaluatedItems (2020-12 feature)
+    #[test]
+    fn unevaluated_items() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "prefixItems": [
+                { "type": "string" }
+            ],
+            "unevaluatedItems": false
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test contains with minContains and maxContains (2020-12 enhancements)
+    #[test]
+    fn contains_with_bounds() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "array",
+            "contains": { "type": "integer" },
+            "minContains": 1,
+            "maxContains": 3
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test backward compatibility with draft-07 definitions
+    #[test]
+    fn backward_compat_definitions() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "definitions": {
+                "name": { "type": "string" }
+            },
+            "type": "object"
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
+    }
+
+    /// Test backward compatibility with draft-07 dependencies
+    #[test]
+    fn backward_compat_dependencies() {
+        let raw_schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+            },
+            "dependencies": {
+                "a": ["b"]
+            }
+        }"#;
+
+        let schema = Schema::try_from(raw_schema).unwrap();
+        println!("{:#?}", schema);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -560,38 +560,4 @@ mod json_schema_2020_12 {
         let schema = Schema::try_from(raw_schema).unwrap();
         println!("{:#?}", schema);
     }
-
-    /// Test backward compatibility with draft-07 definitions
-    #[test]
-    fn backward_compat_definitions() {
-        let raw_schema = r#"{
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "definitions": {
-                "name": { "type": "string" }
-            },
-            "type": "object"
-        }"#;
-
-        let schema = Schema::try_from(raw_schema).unwrap();
-        println!("{:#?}", schema);
-    }
-
-    /// Test backward compatibility with draft-07 dependencies
-    #[test]
-    fn backward_compat_dependencies() {
-        let raw_schema = r#"{
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-            "properties": {
-                "a": { "type": "string" },
-                "b": { "type": "string" }
-            },
-            "dependencies": {
-                "a": ["b"]
-            }
-        }"#;
-
-        let schema = Schema::try_from(raw_schema).unwrap();
-        println!("{:#?}", schema);
-    }
 }


### PR DESCRIPTION
This PR adds updates support for this crate to JSON Schema 2020-12. It is however entirely generated using an AI model, and so I cannot guarantee that it is correct. I'm filing this PR as a reference only, to give rough idea of which changes would be necessary.

I'm currently prototyping a tool for work, and this patch has allowed me to successfully parse a 2020-12 schema. My intent is that once the prototype has proven to work, I will be able to come back to this and sit down to add support for JSON Schema 2020-12 in earnest.

@hoodie would you be open to a future PR which updates the version of JSON Schema to 2020-12 (e.g. implementing #5)?